### PR TITLE
Fixes to a few problems that arise during installation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,4 +7,4 @@ default[:riemann][:riemann_tarball_location] = "http://aphyr.com/riemann/riemann
 default[:riemann][:riemann_install_location] = "/opt/riemann"
 default[:riemann][:riemann_tarball] = "riemann-0.2.0.tar.bz2"
 default[:riemann][:riemann_version] = "riemann-0.2.0"
-default[:riemann][:jdk_package] = "openjdk-8-jdk"
+default[:riemann][:jdk_package] = "openjdk-7-jdk"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,3 +7,4 @@ default[:riemann][:riemann_tarball_location] = "http://aphyr.com/riemann/riemann
 default[:riemann][:riemann_install_location] = "/opt/riemann"
 default[:riemann][:riemann_tarball] = "riemann-0.2.0.tar.bz2"
 default[:riemann][:riemann_version] = "riemann-0.2.0"
+default[:riemann][:jdk_package] = "openjdk-8-jdk"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "jj.asghar@peopleadmin.com"
 license          "Apache 2.0"
 description      "Installs/Configures riemann client and server"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.0"
+version          "1.0.1"

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "riemann"
 maintainer       "JJ Asghar"
 maintainer_email "jj.asghar@peopleadmin.com"
 license          "Apache 2.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "jj.asghar@peopleadmin.com"
 license          "Apache 2.0"
 description      "Installs/Configures riemann client and server"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.1"
+version          "1.0.2"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -6,10 +6,14 @@
 
 execute "apt-get update"
 
-%w{build-essential wget libyaml-dev zlib1g-dev libreadline-dev libssl-dev tk-dev libgdbm-dev openjdk-6-jdk gem}.each do |pkg|
+%w{build-essential wget libyaml-dev zlib1g-dev libreadline-dev libssl-dev tk-dev libgdbm-dev gem}.each do |pkg|
   package pkg do
     action [:install]
   end
+end
+
+package node[:riemann][:jdk] do
+  action [:install]
 end
 
 script "install_riemann" do

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -22,7 +22,7 @@ script "install_riemann" do
   wget #{node[:riemann][:riemann_tarball_location]} || STATUS=1
   mkdir #{node[:riemann][:riemann_install_location]} || STATUS=1
   tar xvfj /opt/#{node[:riemann][:riemann_tarball]} || STATUS=1
-  cp /opt/#{node[:riemann][:riemann_version]}/* /opt/riemann/
+  cp -R /opt/#{node[:riemann][:riemann_version]}/* /opt/riemann/
   rm -rf /opt/#{node[:riemann][:riemann_version]}
   exit $STATUS
   EOH

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -12,7 +12,7 @@ execute "apt-get update"
   end
 end
 
-package node[:riemann][:jdk] do
+package node[:riemann][:jdk_package] do
   action [:install]
 end
 


### PR DESCRIPTION
* Name param inside metadata.rb
* cp command made recursive as it was failing to copy the sub folders
* default openjdk version changed as the newer versions of riemann require jdk > 1.6
* ability to set jdk version inside attributes if a different version is required